### PR TITLE
Adding Years + Maximum Scores

### DIFF
--- a/get_best_scores.py
+++ b/get_best_scores.py
@@ -19,6 +19,25 @@ def f_measure(p, r):
     return 2 * p * r / (p + r)
 
 
+def print_latex_table():
+    tbl = r"\begin{tabular}{ c|c c c c }" + '\n Datasets '
+    for metric in METRICS:
+        tbl += f"& {metric} "
+    tbl += r"\\" + '\n'
+    tbl += r"\hline" + '\n '
+    for ds in RES.keys():
+        tbl += f"{ds} "
+        for metric in METRICS:
+            try:
+                tbl += f"& {RES[ds][metric] * 100:.2f} \pm {STD[ds][metric] * 100:.2f} ({NAMES[ds][metric]}) "
+            except KeyError:
+                tbl += "& -- "
+        tbl += r"\\" + '\n'
+    tbl += r"\hline" + '\n'
+    tbl += r"\end{tabular}"
+    print(tbl)
+
+
 def update_dicts(metric, mean, std, ds, algo, year):
     ds = "salami" if ds == "sal" else ds
     if ds == "mrx10_1" and (metric == "F_nce" or metric == "F_p"):
@@ -49,6 +68,7 @@ def main():
     print(RES)
     print(STD)
     print(NAMES)
+    print_latex_table()
 
 
 if __name__ == "__main__":

--- a/get_best_scores.py
+++ b/get_best_scores.py
@@ -1,0 +1,55 @@
+import glob
+import os
+import pandas as pd
+from tqdm import tqdm
+from collections import defaultdict
+
+PATH = "./mirex_data"
+METRICS = ["F_0.5", "F_3", "F_p", "F_nce"]
+RES = {}
+RES["mrx09"] = {x: 0 for x in METRICS}
+RES["mrx10_1"] = {x: 0 for x in METRICS}
+RES["mrx10_2"] = {x: 0 for x in METRICS}
+RES["salami"] = {x: 0 for x in METRICS}
+STD = defaultdict(dict)
+NAMES = defaultdict(dict)
+
+
+def f_measure(p, r):
+    return 2 * p * r / (p + r)
+
+
+def update_dicts(metric, mean, std, ds, algo, year):
+    ds = "salami" if ds == "sal" else ds
+    if ds == "mrx10_1" and (metric == "F_nce" or metric == "F_p"):
+        # Do not store labeling results for mrx10_1 dataset
+        return
+    if mean > RES[ds][metric]:
+        RES[ds][metric] = mean
+        STD[ds][metric] = std
+        NAMES[ds][metric] = f"{algo}_{year}"
+
+
+def process_summary(summary_file):
+    _, _, year, ds, algo, _ = summary_file.split("/")
+    df = pd.read_csv(summary_file)
+    df.columns = ["fold", "track", "nce_o", "nce_u", "F_p", "P_p", "R_p", "rci",
+                  "F_0.5", "P_0.5", "R_0.5", "F_3", "P_3", "R_3", "M_ap", "M_pa"]
+    df["F_nce"] = df.apply(lambda x: f_measure(x["nce_o"], x["nce_u"]), axis=1)
+    mean = df.mean()
+    std = df.std()
+    for metric in METRICS:
+        update_dicts(metric, mean[metric], std[metric], ds, algo, year)
+
+
+def main():
+    all_summaries = glob.glob(os.path.join(PATH, "*", "*", "*", "per_track_results.csv"))
+    for summary_file in tqdm(all_summaries):
+        process_summary(summary_file)
+    print(RES)
+    print(STD)
+    print(NAMES)
+
+
+if __name__ == "__main__":
+    main()

--- a/get_mirex_estimates.rb
+++ b/get_mirex_estimates.rb
@@ -1,5 +1,7 @@
 require "CSV"
 require "open-uri"
+require 'fileutils'
+require 'net/http'
 
 # Usage:
 #   ruby get_mirex_estimates.rb
@@ -13,8 +15,9 @@ require "open-uri"
 #     -> Run only Part 2.
 
 def url_download(uri, filename=".")
+    puts("Downloading %s...\n" % [uri])
     open(filename, 'w') do |foo|
-        foo.print open(uri).read
+        foo.print URI.open(uri).read
     end
 end
 
@@ -51,59 +54,73 @@ def downloadMIREXdata(mirex_path)
   # # # #         PART 1: DOWNLOAD ALL THE STRUCTURAL ANALYSIS EVALUTION DATA PUBLISHED BY MIREX
 
   # Define list of algorithms and datasets:
-  datasets = ["mrx09", "mrx10_1", "mrx10_2", "sal"]
+  algos_year = {
+    "2012" => ["SP1", "SMGA2", "MHRAF1", "SMGA1", "SBV1", "KSP2", "OYZS1", "KSP3", "KSP1"],
+    "2013" => ["RBH1","RBH2","RBH3","RBH4","MP1","MP2","CF5","CF6"],
+    "2014" => ["SUG1","SUG2","NJ1","NB1","NB2","NB3"],
+    "2015" => ["CC1","GS1","GS3","MC1"],
+    "2016" => ["CC1","MC1","ON1","ON2","ON3","ON4","ON5"],
+    "2017" => ["CC1","CM1"]
+  }
 
-  algos = ["SP1", "SMGA2", "MHRAF1", "SMGA1", "SBV1", "KSP2", "OYZS1", "KSP3", "KSP1"]
-  year = "2012"
-
-  algos = ["RBH1","RBH2","RBH3","RBH4","MP1","MP2","CF5","CF6"]
-  year = "2013"
-
-  algos = ["SUG1","SUG2","NJ1","NB1","NB2","NB3"]
-  year = "2014"
+  ds_year = {
+    "2012" => ["mrx09", "mrx10_1", "mrx10_2", "sal"],
+    "2013" => ["mrx09", "mrx10_1", "mrx10_2", "sal"],
+    "2014" => ["mrx09", "mrx10_1", "mrx10_2", "sal"],
+    "2015" => ["mrx09", "mrx10_1", "mrx10_2", "salami"],
+    "2016" => ["mrx09", "mrx10_1", "mrx10_2", "salami"],
+    "2017" => ["mrx09", "mrx10_1", "mrx10_2", "salami"]
+  }
+  mirex_url = "https://nema.lis.illinois.edu/nema_out/mirex"
 
   # Create appropriate directory tree and download CSV files:
   Dir.mkdir(mirex_path) unless File.directory?(mirex_path)
   puts("Downloading CSV files...\n")
-  datasets.each do |dset|
-      # Make dataset directory:
-      dir_path = File.join(mirex_path,year,dset)
-      Dir.mkdir(dir_path) unless File.directory?(dir_path)
-      algos.each do |algo|
-          # Make algorithm directory:
-          algo_path = File.join(dir_path,algo)
-          Dir.mkdir(algo_path) unless File.directory?(algo_path)
-          # Download the CSV file to this directory:
-          algocsvpath = File.join(algo_path,"per_track_results.csv")
-          csv_path = File.join(("http://nema.lis.illinois.edu/nema_out/mirex"+year),"/results/struct",dset,algo,"per_track_results.csv")
-          url_download(csv_path, algocsvpath)
+  algos_year.each do | year, algos |
+      datasets = ds_year[year]
+      datasets.each do |dset|
+          # Make dataset directory:
+          dir_path = File.join(mirex_path,year,dset)
+          #Dir.mkdir(dir_path) unless File.directory?(dir_path)
+          FileUtils.mkdir_p(dir_path) unless File.directory?(dir_path)
+          algos.each do |algo|
+              # Make algorithm directory:
+              algo_path = File.join(dir_path,algo)
+              Dir.mkdir(algo_path) unless File.directory?(algo_path)
+              # Download the CSV file to this directory:
+              algocsvpath = File.join(algo_path,"per_track_results.csv")
+              csv_path = File.join((mirex_url+year),"/results/struct",dset,algo,"per_track_results.csv")
+              url_download(csv_path, algocsvpath)
+          end
       end
   end
 
   puts "..done with that."
 
   puts "Now we will download all the files output by each algorithm. This could take a while depending on your connection."
-  puts "Since this script points to " + datasets.length.to_s + " datasets and " + algos.length.to_s + " algorithms, you should expect to wait however long it takes between each of the next lines to appear, times " + (datasets.length*algos.length).to_s + "."
+  #puts "Since this script points to " + datasets.length.to_s + " datasets and " + algos.length.to_s + " algorithms, you should expect to wait however long it takes between each of the next lines to appear, times " + (datasets.length*algos.length).to_s + "."
 
   # Read each CSV file and download all the json files it points to:
-  datasets.each do |dset|
-      algos.each do |algo|
-          puts( "Starting to download "+dset+ " dataset for " + algo + " algorithm...\n")
-          download_folder = File.join(mirex_path,year,dset,algo)
-          algocsvpath = File.join(download_folder,"per_track_results.csv")
-          csv_data = File.read(algocsvpath).split("\n")
-          header = csv_data.delete_at(0)
-          # For each line in the spreadsheet, extract the songid and download the corresponding json document.
-          csv_data.each do |line|
-              line = line.split(",")
-              song_id = line[1]
-              url = "http://nema.lis.illinois.edu/nema_out/mirex" + year + "/results/struct/" + dset + "/" + algo.downcase + "segments" + song_id.delete("_") + ".js"
-              download_path = File.join(download_folder,song_id + ".js")
-              # download_path = download_folder + "/" + song_id + ".js"
-              url_download(url, download_path)
+  algos_year.each do | year, algos |
+      datasets = ds_year[year]
+      datasets.each do |dset|
+          algos.each do |algo|
+              puts( "Starting to download "+dset+ " dataset for " + algo + " algorithm...\n")
+              download_folder = File.join(mirex_path,year,dset,algo)
+              algocsvpath = File.join(download_folder,"per_track_results.csv")
+              csv_data = File.read(algocsvpath).split("\n")
+              header = csv_data.delete_at(0)
+              # For each line in the spreadsheet, extract the songid and download the corresponding json document.
+              csv_data.each do |line|
+                  line = line.split(",")
+                  song_id = line[1]
+                  url = mirex_url + year + "/results/struct/" + dset + "/" + algo.downcase + "segments" + song_id.delete("_") + ".js"
+                  download_path = File.join(download_folder,song_id + ".js")
+                  url_download(url, download_path)
+              end
           end
+          puts("Done with " + dset + " dataset!\n")
       end
-      puts("Done with " + dset + " dataset!\n")
   end
 
   puts "..done with that."
@@ -125,16 +142,30 @@ end
 
 def downloadAnnotationData(mirex_path)
   puts "PART 2 of the script: we download all the zip files (from various websites) that contain the public collections of ground truth files. This will only take a couple minutes, depending on connection speed (it's about 4 MB total)."
-  
+
   # Download and unzip all public annotations
-  list_of_db_urls = ["https://staff.aist.go.jp/m.goto/RWC-MDB/AIST-Annotation/AIST.RWC-MDB-P-2001.CHORUS.zip", "https://staff.aist.go.jp/m.goto/RWC-MDB/AIST-Annotation/AIST.RWC-MDB-C-2001.CHORUS.zip", "https://staff.aist.go.jp/m.goto/RWC-MDB/AIST-Annotation/AIST.RWC-MDB-J-2001.CHORUS.zip", "https://staff.aist.go.jp/m.goto/RWC-MDB/AIST-Annotation/AIST.RWC-MDB-G-2001.CHORUS.zip", "http://www.music.mcgill.ca/~jordan/salami/releases/SALAMI_data_v1.2.zip", "http://www.ifs.tuwien.ac.at/mir/audiosegmentation/dl/ep_groundtruth_excl_Paulus.zip", "http://musicdata.gforge.inria.fr/IRISA.RWC-MDB-P-2012.SEMLAB_v003_full.zip", "http://musicdata.gforge.inria.fr/IRISA.RWC-MDB-P-2012.SEMLAB_v003_reduced.zip", "http://musicdata.gforge.inria.fr/IRISA.RWC-MDB-P-2001.BLOCKS_v001.zip", "http://www.isophonics.net/files/annotations/The%20Beatles%20Annotations.tar.gz", "http://www.isophonics.net/files/annotations/Carole%20King%20Annotations.tar.gz", "http://www.isophonics.net/files/annotations/Queen%20Annotations.tar.gz", "http://www.isophonics.net/files/annotations/Michael%20Jackson%20Annotations.tar.gz", "http://www.isophonics.net/files/annotations/Zweieck%20Annotations.tar.gz", "http://www.cs.tut.fi/sgn/arg/paulus/beatles_sections_TUT.zip", "http://www.iua.upf.edu/~perfe/annotations/sections/beatles/structure_Beatles.rar"]
+  list_of_db_urls = [
+    "https://staff.aist.go.jp/m.goto/RWC-MDB/AIST-Annotation/AIST.RWC-MDB-P-2001.CHORUS.zip",
+    "https://staff.aist.go.jp/m.goto/RWC-MDB/AIST-Annotation/AIST.RWC-MDB-C-2001.CHORUS.zip",
+    "https://staff.aist.go.jp/m.goto/RWC-MDB/AIST-Annotation/AIST.RWC-MDB-J-2001.CHORUS.zip",
+    "https://staff.aist.go.jp/m.goto/RWC-MDB/AIST-Annotation/AIST.RWC-MDB-G-2001.CHORUS.zip",
+    "https://github.com/DDMAL/salami-data-public/archive/1.2.zip",
+    "http://www.ifs.tuwien.ac.at/mir/audiosegmentation/dl/ep_groundtruth_excl_Paulus.zip",
+    "http://musicdata.gforge.inria.fr/IRISA.RWC-MDB-P-2012.SEMLAB_v003_full.zip",
+    "http://musicdata.gforge.inria.fr/IRISA.RWC-MDB-P-2012.SEMLAB_v003_reduced.zip",
+    "http://musicdata.gforge.inria.fr/IRISA.RWC-MDB-P-2001.BLOCKS_v001.zip",
+    "http://www.isophonics.net/files/annotations/The%20Beatles%20Annotations.tar.gz",
+    "http://www.isophonics.net/files/annotations/Carole%20King%20Annotations.tar.gz",
+    "http://www.isophonics.net/files/annotations/Queen%20Annotations.tar.gz",
+    "http://www.isophonics.net/files/annotations/Michael%20Jackson%20Annotations.tar.gz",
+    "http://www.isophonics.net/files/annotations/Zweieck%20Annotations.tar.gz",
+    "http://www.cs.tut.fi/sgn/arg/paulus/beatles_sections_TUT.zip"]
+    #"http://www.iua.upf.edu/~perfe/annotations/sections/beatles/structure_Beatles.rar"]  # This one is no longer valid
 
   public_data_path = File.join(mirex_path,"public_data")
   Dir.mkdir(public_data_path) unless File.directory?(public_data_path)
   list_of_db_urls.each do |db_url|
-      open(File.join(public_data_path,File.basename(db_url)), 'wb') do |foo|
-        foo.print open(db_url).read
-      end
+      url_download(db_url, File.join(public_data_path,File.basename(db_url)))
   end
   puts "..done with that.\n\n"
   puts "Script apppears to have ended successfully. All files were downloaded and saved to " + public_data_path +"."


### PR DESCRIPTION
I updated the `get_best_scores.py` script such that it not only downloads all data at once, but also downloads the newest MIREX results (so, total it goes from 2012 to 2017).

Moreover, I added a little Python script to compute the maximum scores for all years, datasets, and a subset of all the scores (Hit Scores of 0.5 and 3, Pairwise-Clustering, and Normalized Conditional Entropies).

Note: One of the links for the reference annotations is no longer available (http://www.iua.upf.edu/~perfe/annotations/sections/beatles/structure_Beatles.rar). I left it there as a comment, since I'm not sure where to find it.